### PR TITLE
Enable golang compilation for 32 bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,10 @@ These instructions will get you a copy of the project and its dependencies in yo
     3. Decompress the installer: `sudo tar -C /usr/local -xvzf YOUR_GOLANG_FILE`
     4. Export to PATH: `export PATH=$PATH:/usr/local/go/bin`
     5. Set GOPATH: `export GOPATH="$HOME/go"`
-6. Download go dependencies:
-    1. `go get github.com/tidwall/sjson && go get github.com/tidwall/gjson && go get github.com/matiassequeira/lorawan && go get github.com/pkg/errors && go get github.com/sirupsen/logrus && go get golang.org/x/crypto/sha3`
-7. Compile go library:
+6. Compile go library:
     1. `cd laf/lorawanwrapper/utils`
     2. `go build -o lorawanWrapper.so -buildmode=c-shared jsonUnmarshaler.go lorawanWrapper.go micGenerator.go sessionKeysGenerator.go hashGenerator.go`
-8. Depending on which DB you'd like to use:
+7. Depending on which DB you'd like to use:
 
     a. PostreSQL: Follow instructions 'Install LAF using Docker' until 3rd step.
 

--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ This script receives UDP packets from the UDP proxy in the gateway
 packet_forwarder format and persists them.
 
 Optional arguments:
+
     -h, --help            show this help message and exit
     --collector-id COLLECTOR_ID
                             The ID of the dataCollector. This ID will be
@@ -484,9 +485,10 @@ Optional arguments:
                         associated to the packets saved into DB. eg. --id 1
 
 Required arguments:
-  -n NAME, --name NAME  Unique string identifier of the Data Collector. eg.
+
+    -n NAME, --name NAME  Unique string identifier of the Data Collector. eg.
                         --name semtech_collector
-  -p PORT, --port PORT  Port where to listen for UDP packets. --port 1702.
+    -p PORT, --port PORT  Port where to listen for UDP packets. --port 1702.
 
 Example:
 

--- a/lorawanwrapper/utils/lorawanWrapper.go
+++ b/lorawanwrapper/utils/lorawanWrapper.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 	"unsafe"
+	"math"
 
 	. "github.com/matiassequeira/lorawan"
 	log "github.com/sirupsen/logrus"
@@ -300,7 +301,8 @@ func testAppKeysWithJoinRequest(appKeysPointer **C.char, keysLen C.int, joinRequ
 	Test keys given in keys file
 	********************************************************************/
 	length := int(keysLen)
-	tmpslice := (*[1 << 30]*C.char)(unsafe.Pointer(appKeysPointer))[:length:length]
+	var temp *C.char
+	tmpslice := (*[(math.MaxInt32 -1)/unsafe.Sizeof(temp)]*C.char)(unsafe.Pointer(appKeysPointer))[:length:length]
 	for _, s := range tmpslice {
 		element := C.GoString(s)
 
@@ -523,7 +525,8 @@ func testAppKeysWithJoinAccept(appKeysPointer **C.char, keysLen C.int, joinAccep
 	}
 
 	length := int(keysLen)
-	tmpslice := (*[1 << 30]*C.char)(unsafe.Pointer(appKeysPointer))[:length:length]
+	var temp *C.char
+	tmpslice := (*[(math.MaxInt32 - 1)/unsafe.Sizeof(temp)]*C.char)(unsafe.Pointer(appKeysPointer))[:length:length]
 	for _, s := range tmpslice {
 		element := C.GoString(s)
 


### PR DESCRIPTION
Hey,

first of all, thank you for this nice suite of tools and the research that you did on lorawan security. It helps me a lot in pentesting a lora infrastructure.

While setting it up on a raspberry pi with a 32 bit architecture, I ran into compilation problems while trying to compile the go libraries.
```bash
$ go build -o lorawanWrapper.so -buildmode=c-shared jsonUnmarshaler.go lorawanWrapper.go micGenerator.go sessionKeysGenerator.go hashGenerator.go
# command-line-arguments
./lorawanWrapper.go:303:16: type [1073741824]*_Ctype_char larger than address space                                                                                                                          
./lorawanWrapper.go:303:16: type [1073741824]*_Ctype_char too large                                                                                                                                          
./lorawanWrapper.go:526:16: type [1073741824]*_Ctype_char larger than address space                                                                                                                          
./lorawanWrapper.go:526:16: type [1073741824]*_Ctype_char too large
```

This is caused by `tmpslice := (*[1 << 30]*C.char)(unsafe.Pointer(appKeysPointer))[:length:length]` but can be fixed by using `	tmpslice := (*[(math.MaxInt32 -1)/unsafe.Sizeof(temp)]*C.char)(unsafe.Pointer(appKeysPointer))[:length:length]` instead. The size should still be enough imo and since a lot of lorawan hardware runs on older raspberry pis, this could be helpful to some. I also fixed a missing code formatting in the readme in this PR.

Best wishes
