### PR TITLE
Safely close socket

### DIFF
--- a/tools/UdpSender.py
+++ b/tools/UdpSender.py
@@ -120,16 +120,14 @@ def receiver(send_socket, timeout):
 
     try:
         data, source_address = send_socket.recvfrom(65565)
+        if not data:
+            logger.error('an error ocurred')
+        else:
+            logger.debug('Received UDP. Source {0}. Local port {1}:\n{2!r}{3}'.format(source_address, send_socket.getsockname()[1], data, formatData(data)))
     except socket.timeout as exc:
         print("Timed out receive window")
-        return
-
-    send_socket.close()
-
-    if not data:
-        logger.error('an error ocurred')    
-    else:
-        logger.debug('Received UDP. Source {0}. Local port {1}:\n{2!r}{3}'.format(source_address, send_socket.getsockname()[1], data, formatData(data)))
+    finally:
+        send_socket.close()
 
 def udp_sender(data, repeat, fuzz_out_mode, key, dev_address, timeout, new_counter, local_port, remote_ip, remote_port):
 


### PR DESCRIPTION
Hey,

In the UdpSender, when a response is received, the socket is closed before the response is logged. The logging calls `send_socket.getsockname()` which is causing an exception due to being called on a closed socket.
```
Traceback (most recent call last):
  File "/home/pi/laf/tools/UdpSender.py", line 139, in udp_sender
    sender(data, fuzz_out_mode, key, dev_address, timeout, new_counter, local_port, remote_ip, remote_port)
  File "/home/pi/laf/tools/UdpSender.py", line 116, in sender
    receiver(send_socket, timeout)
  File "/home/pi/laf/tools/UdpSender.py", line 133, in receiver
    logger.debug('Received UDP. Source {0}. Local port {1}:\n{2!r}{3}'.format(source_address, send_socket.getsockname()[1], data, formatData(data)))
OSError: [Errno 9] Bad file descriptor
```
Closing the socket after logging fixes this.

Best wishes